### PR TITLE
Changed hostname default of localhost to null

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Default: `'localhost'`
 
 The hostname the webserver will use.
 
+Setting it to * will make the server accessible from anywhere.
+
 #### base
 Type: `String`
 Default: `'.'`

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -37,6 +37,11 @@ module.exports = function(grunt) {
     // Connect requires the base path to be absolute.
     options.base = path.resolve(options.base);
 
+    // Connect will listen to all interfaces if hostname is null.
+    if (options.hostname === '*') {
+      options.hostname = null;
+    }
+
     var middleware = options.middleware ? options.middleware.call(this, connect, options) : [];
 
     // If --debug was specified, enable logging.
@@ -47,7 +52,7 @@ module.exports = function(grunt) {
     }
 
     // Start server.
-    grunt.log.writeln('Starting connect web server on ' + options.hostname + ':' + options.port + '.');
+    grunt.log.writeln('Starting connect web server on ' + (options.hostname || '*') + ':' + options.port + '.');
 
     connect.apply(null, middleware)
       .listen(options.port, options.hostname)


### PR DESCRIPTION
Hi guys,

The default `localhost` binding can be bothering when you want to access your server from other devices for example.
You have to explicitly set the hostname value to `null` in the config.

By defaulting the value to `null`, the server can be accessed by any suitable pointer to it (IP, os hostname, localhost).
If the user wants to restrict the access, then the config can be modified to explicitly listen on a given hostname, `localhost` for example.
