### PR TITLE
Fixing log and config line which indicates which address the server is running on.

### DIFF
--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -61,8 +61,8 @@ module.exports = function(grunt) {
       .listen(options.port, options.hostname)
       .on('listening', function() {
         var address = server.address();
-        grunt.log.writeln('Started connect web server on ' + (address.host || 'localhost') + ':' + address.port + '.');
-        grunt.config.set('connect.' + taskTarget + '.options.host', address.host || 'localhost');
+        grunt.log.writeln('Started connect web server on ' + (address.address || 'localhost') + ':' + address.port + '.');
+        grunt.config.set('connect.' + taskTarget + '.options.host', address.address || 'localhost');
         grunt.config.set('connect.' + taskTarget + '.options.port', address.port);
 
         if (!keepAlive) {


### PR DESCRIPTION
The log and config lines look for address.host which is a non-existent property. address.address is the correct property's name.
