### PR TITLE
Add an `open` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Set to `true` or a port number to inject a live reload script tag into your page
 
 *This does not perform live reloading. It is intended to be used in tandem with grunt-contrib-watch or another task that will trigger a live reload server upon files changing.*
 
+#### open
+Type: `Boolean` or `String`
+Default: `false`
+
+Open the served page in your default browser. Specifying `true` opens the default server URL, while specifying a URL opens that URL.
+
 #### middleware
 Type: `Function`  
 Default:
@@ -271,4 +277,4 @@ grunt.registerTask('jasmine-server', 'start web server for jasmine tests in brow
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com)
 
-*This file was generated on Thu Sep 05 2013 13:10:30.*
+*This file was generated on Thu Sep 05 2013 22:15:37.*

--- a/docs/connect-options.md
+++ b/docs/connect-options.md
@@ -56,6 +56,12 @@ Set to `true` or a port number to inject a live reload script tag into your page
 
 *This does not perform live reloading. It is intended to be used in tandem with grunt-contrib-watch or another task that will trigger a live reload server upon files changing.*
 
+## open
+Type: `Boolean` or `String`
+Default: `false`
+
+Open the served page in your default browser. Specifying `true` opens the default server URL, while specifying a URL opens that URL.
+
 ## middleware
 Type: `Function`  
 Default:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "connect": "~2.7.11",
-    "connect-livereload": "~0.2.0"
+    "connect-livereload": "~0.2.0",
+    "open": "0.0.4"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.4",

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -14,6 +14,7 @@ module.exports = function(grunt) {
   var http = require('http');
   var https = require('https');
   var injectLiveReload = require('connect-livereload');
+  var open = require('open');
 
   grunt.registerMultiTask('connect', 'Start a connect web server.', function() {
     // Merge task-specific options with these defaults.
@@ -26,6 +27,7 @@ module.exports = function(grunt) {
       keepalive: false,
       debug: false,
       livereload: false,
+      open: false,
       middleware: function(connect, options) {
         var middlewares = [];
         var directory = options.directory || options.base[options.base.length - 1];
@@ -110,6 +112,12 @@ module.exports = function(grunt) {
         grunt.config.set('connect.' + taskTarget + '.options.port', address.port);
 
         grunt.event.emit('connect.' + taskTarget + '.listening', (address.address || 'localhost'), address.port);
+
+        if (options.open === true) {
+          open(options.protocol + '://' + address.address + ':' + address.port);
+        } else if (typeof options.open === 'string') {
+          open(options.open);
+        }
 
         if (!keepAlive) {
           done();


### PR DESCRIPTION
It's such a common usecase.
