### PR TITLE
Accepting other certificates options

### DIFF
--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -15,6 +15,7 @@ module.exports = function(grunt) {
   var https = require('https');
   var injectLiveReload = require('connect-livereload');
   var open = require('open');
+  var fs = require('fs');
 
   grunt.registerMultiTask('connect', 'Start a connect web server.', function() {
     // Merge task-specific options with these defaults.
@@ -93,7 +94,7 @@ module.exports = function(grunt) {
     var server = null;
 
     if (options.protocol === 'https') {
-      server = https.createServer({
+      server = https.createServer(options.certs && options.certs.call(this) || {
         key: options.key || grunt.file.read(path.join(__dirname, 'certs', 'server.key')).toString(),
         cert: options.cert || grunt.file.read(path.join(__dirname, 'certs', 'server.crt')).toString(),
         ca: options.ca || grunt.file.read(path.join(__dirname, 'certs', 'ca.crt')).toString(),


### PR DESCRIPTION
I noticed that the only option to use certificates is using CA. I added an options called "certs" to be able to use other options. I made it a function and call it with the connect.js context in order to use fs dependency.
