### PR TITLE
Added onCreateServer callback option to allow post server creation modifications

### DIFF
--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -105,7 +105,7 @@ module.exports = function(grunt) {
     }
 
     if (options.onCreateServer && typeof options.onCreateServer === 'function'){
-      options.onCreateServer.call(null,server,connect);    
+      options.onCreateServer.call(null, server, connect, options);   
     }
 
     server


### PR DESCRIPTION
This is required to integrate libraries like sockjs that requires post server creation modification to inject handlers.
