### PR TITLE
Don't use resolved IP when opening URL

### DIFF
--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -107,7 +107,7 @@ module.exports = function(grunt) {
       .listen(options.port, options.hostname)
       .on('listening', function() {
         var address = server.address();
-        var hostname = options.hostname || address.address || 'localhost';
+        var hostname = options.hostname || 'localhost';
         var target = options.protocol + '://' + hostname + ':' + address.port;
 
         grunt.log.writeln('Started connect web server on ' + target);


### PR DESCRIPTION
When the `hostname` option is set to either `'*'` or `'localhost'`, Connect will listen on all interfaces and the value of `server.address().address` will be "0.0.0.0", but this is not a valid destination IP.

On Windows, no browser will be able to open a URL that starts with "http://0.0.0.0". Therein lies the reason for this push request. I have to manually change "0.0.0.0" in the URL to "localhost" after every fresh run of `grunt serve`.

It works on OSX (and also possibly on all Linux) because of some seemingly non-standard behaviour of the network stack: "0.0.0.0" resolves or loops back to "127.0.0.1" somehow. I couldn't find any references to this particular behaviour of the Linux network stack, but it is clearly against the spec. As per RFC1700, an address starting with "0" can only be used as a source address.

Also, as per the documentation for `server.address()`, the `address` property of the returned object should always be set. I've verified this on both Windows on OSX -- listening on "*" results in "0.0.0.0" always. I can't think of any case where `address` can be falsy.
