### PR TITLE
Enhancements to `options.middleware`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,18 +35,21 @@ module.exports = function(grunt) {
       },
       custom_port: {
         options: {
-          port: 9000,
+          base: 'test',
+          port: 8001,
         },
       },
       custom_https: {
         options: {
-          port: 8001,
+          base: 'test',
+          port: 8002,
           protocol: 'https',
         }
       },
       custom_https_certs: {
         options: {
-          port: 8002,
+          base: 'test',
+          port: 8003,
           protocol: 'https',
           key: grunt.file.read(path.join(certs, 'server.key')).toString(),
           cert: grunt.file.read(path.join(certs, 'server.crt')).toString(),
@@ -54,39 +57,78 @@ module.exports = function(grunt) {
           passphrase: 'grunt',
         }
       },
-      custom_middleware: {
-        options: {
-          port: 9001,
-          base: '.',
-          middleware: function(connect, options) {
-            // Return array of whatever middlewares you want
-            return [
-              connect.static(options.base),
-              function(req, res, next) {
-                res.end('Hello from port ' + options.port);
-              }
-            ];
-          },
-        },
-      },
       multiple_base: {
         options: {
           base: ['test', 'docs'],
-          port: 9002,
+          port: 8004,
         },
       },
       multiple_base_directory: {
         options: {
           base: ['test', 'docs'],
           directory: 'test/fixtures/',
-          port: 9003,
+          port: 8005,
         },
       },
       livereload: {
         options: {
           livereload: true,
           base: 'test/fixtures/',
-          port: 9004,
+          port: 8006,
+        },
+      },
+      custom_middleware: {
+        options: {
+          port: 8007,
+          base: 'test',
+          middleware: function(connect, options, middlwares) {
+            // an explicit array of any middlewares that ignores the default set
+            return [
+              connect.static(options.base[0]),
+
+              function(req, res, next) {
+                if (req.url !== '/hello/world') {
+                  next();
+                  return;
+                }
+                res.end('Hello from port ' + options.port);
+              }
+            ];
+          },
+        },
+      },
+      null_middleware: {
+        options: {
+          port: 8008,
+          base: 'test/',
+          middleware: null
+        },
+      },
+      empty_middleware: {
+        options: {
+          port: 8009,
+          base: 'test/',
+          middleware: []
+        },
+      },
+      custom_middleware_patch_default_middleware: {
+        options: {
+          port: 8010,
+          base: 'test/',
+          middleware: function(connect, options, middlewares) {
+            // inject a custom middleware into the array of default middlewares
+            // this is likely the easiest way for other grunt plugins to
+            // extend the behavior of grunt-contrib-connect
+            middlewares.push(function(req, res, next) {
+              if (req.url !== '/hello/world') {
+                return next();
+              }
+
+              res.end('Hello, world from port #' + options.port + '!');
+            });
+
+            return middlewares;
+          },
         },
       },
       useAvailablePort: {

--- a/docs/connect-options.md
+++ b/docs/connect-options.md
@@ -78,26 +78,42 @@ If `true` the task will look for the next available port after the set `port` op
 This also applies to `livereload`.
 
 ## middleware
-Type: `Function`  
-Default:
+Type: `Function` or `Array`
+Default: `Array` of connect middlewares that use `options.base` for static files and directory browsing
+
+As an `Array`:
 
 ```js
 grunt.initConfig({
   connect: {
     server: {
       options: {
-        middleware: function(connect, options) {
-          var middlewares = [];
-          if (!Array.isArray(options.base)) {
-            options.base = [options.base];
+        middleware: [
+          function myMiddleware(req, res, next) {
+            res.end('Hello, world!'');
           }
-          var directory = options.directory || options.base[options.base.length - 1];
-          options.base.forEach(function(base) {
-            // Serve static files.
-            middlewares.push(connect.static(base));
+        ],
+      },
+    },
+  },
           });
-          // Make directory browse-able.
-          middlewares.push(connect.directory(directory));
+```
+
+As a `function`:
+
+```js
+grunt.initConfig({
+  connect: {
+    server: {
+      options: {
+        middleware: function(connect, options, middlewares) {
+          // inject a custom middleware into the array of default middlewares
+          middlewares.push(function(req, res, next) {
+            if (req.url !== '/hello/world') return next();
+
+            res.end('Hello, world from port #' + options.port + '!');
+          });
+
           return middlewares;
         },
       },

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -20,6 +20,21 @@ module.exports = function(grunt) {
 
   var MAX_PORTS = 30; // Maximum available ports to check after the specified port
 
+  var createDefaultMiddleware = function createDefaultMiddleware(connect, options) {
+    var middlewares = [];
+    if (!Array.isArray(options.base)) {
+      options.base = [options.base];
+    }
+    var directory = options.directory || options.base[options.base.length - 1];
+    options.base.forEach(function(base) {
+      // Serve static files.
+      middlewares.push(connect.static(base));
+    });
+    // Make directory browse-able.
+    middlewares.push(connect.directory(directory));
+    return middlewares;
+  };
+
   grunt.registerMultiTask('connect', 'Start a connect web server.', function() {
     var done = this.async();
     // Merge task-specific options with these defaults.
@@ -34,20 +49,7 @@ module.exports = function(grunt) {
       livereload: false,
       open: false,
       useAvailablePort: false,
-      middleware: function(connect, options) {
-        var middlewares = [];
-        if (!Array.isArray(options.base)) {
-          options.base = [options.base];
-        }
-        var directory = options.directory || options.base[options.base.length - 1];
-        options.base.forEach(function(base) {
-          // Serve static files.
-          middlewares.push(connect.static(base));
-        });
-        // Make directory browse-able.
-        middlewares.push(connect.directory(directory));
-        return middlewares;
-      }
+      middleware: null
     });
 
     if (options.protocol !== 'http' && options.protocol !== 'https') {
@@ -73,7 +75,22 @@ module.exports = function(grunt) {
       options.port = 0;
     }
 
-    var middleware = options.middleware ? options.middleware.call(this, connect, options) : [];
+    //  The middleware options may be null, an array of middleware objects,
+    //  or a factory function that creates an array of middleware objects.
+    //  * For a null value, use the default array of middleware
+    //  * For a function, include the default array of middleware as the last arg
+    //    which enables the function to patch the default middleware without needing to know
+    //    the implementation of the default middleware factory function
+    var middleware;
+    if (options.middleware instanceof Array) {
+      middleware = options.middleware;
+    } else {
+      middleware = createDefaultMiddleware.call(this, connect, options);
+
+      if (typeof(options.middleware) === 'function') {
+        middleware = options.middleware.call(this, connect, options, middleware);
+      }
+    }
 
     // If --debug was specified, enable logging.
     if (grunt.option('debug') || options.debug === true) {

--- a/test/connect_test.js
+++ b/test/connect_test.js
@@ -7,8 +7,10 @@ var https = require('https');
 function get(url, done) {
   var client = http;
   if ((typeof url === 'string' && url.toLowerCase().indexOf('https') === 0) ||
-    (typeof url === 'object' && url.port === 443)) {
+    (typeof url === 'object' && url.port === 443) ||
+    (typeof url === 'object' && url.scheme === 'https')) {
     client = https;
+    delete url.scheme;
   }
   client.get(url, function(res) {
     var body = '';
@@ -36,18 +38,69 @@ exports.connect = {
       test.done();
     });
   },
-  multiple_base: function(test) {
+  custom_port: function(test) {
     test.expect(2);
     get({
       hostname: 'localhost',
-      port: 9002,
+      port: 8001,
       path: '/fixtures/hello.txt',
       headers: {
         accept: 'text/plain',
       },
     }, function(res, body) {
       test.equal(res.statusCode, 200, 'should return 200');
-      get('http://localhost:9002/connect-examples.md', function(res, body) {
+      test.equal(body, 'Hello world', 'should return static page');
+      test.done();
+    });
+  },
+  custom_https: function(test) {
+    test.expect(2);
+    get({
+      scheme: 'https',
+      /* per http://nodejs.org/api/https.html#https_https_request_options_callback
+         allow certs signed by an untrusted CA */
+      rejectUnauthorized: false,
+      hostname: 'localhost',
+      port: 8002,
+      path: '/fixtures/hello.txt',
+      headers: {
+        accept: 'text/plain',
+      },
+    }, function(res, body) {
+      test.equal(res.statusCode, 200, 'should return 200');
+      test.equal(body, 'Hello world', 'should return static page');
+      test.done();
+    });
+  },
+  custom_https_certs: function(test) {
+    test.expect(2);
+    get({
+      scheme: 'https',
+      rejectUnauthorized: false,
+      hostname: 'localhost',
+      port: 8003,
+      path: '/fixtures/hello.txt',
+      headers: {
+        accept: 'text/plain',
+      },
+    }, function(res, body) {
+      test.equal(res.statusCode, 200, 'should return 200');
+      test.equal(body, 'Hello world', 'should return static page');
+      test.done();
+    });
+  },
+  multiple_base: function(test) {
+    test.expect(2);
+    get({
+      hostname: 'localhost',
+      port: 8004,
+      path: '/fixtures/hello.txt',
+      headers: {
+        accept: 'text/plain',
+      },
+    }, function(res, body) {
+      test.equal(res.statusCode, 200, 'should return 200');
+      get('http://localhost:8004/connect-examples.md', function(res, body) {
         test.equal(res.statusCode, 200, 'should return 200');
         test.done();
       });
@@ -57,7 +110,7 @@ exports.connect = {
     test.expect(4);
     get({
       hostname: 'localhost',
-      port: 9003,
+      port: 8005,
       path: '/',
       headers: {
         accept: 'text/html',
@@ -65,7 +118,7 @@ exports.connect = {
     }, function(res, body) {
       test.equal(res.statusCode, 200, 'should return 200');
       test.ok((body.indexOf('hello.txt') !== -1), 'Listing should contain hello.txt');
-      get('http://localhost:9003/fixtures/hello.txt', function(res, body) {
+      get('http://localhost:8005/fixtures/hello.txt', function(res, body) {
         test.equal(res.statusCode, 200, 'should return 200');
         test.equal(body, 'Hello world', 'Should display contents of /fixtures/hello.txt');
         test.done();
@@ -76,7 +129,7 @@ exports.connect = {
     test.expect(1);
     get({
       hostname: 'localhost',
-      port: 9004,
+      port: 8006,
       path: '/livereload.html',
       headers: {
         accept: 'text/html',
@@ -84,6 +137,92 @@ exports.connect = {
     }, function(res, body) {
       test.ok((body.indexOf('35729/livereload.js') !== -1), 'Should contain livereload snippet.');
       test.done();
+    });
+  },
+  custom_middleware: function(test) {
+    var PORT = 8007;
+    test.expect(4);
+    get({
+      hostname: 'localhost',
+      port: PORT,
+      path: '/hello/world',
+      headers: {
+        accept: 'text/plain',
+      },
+      middleware: []
+    }, function(res, body) {
+      test.equal(res.statusCode, 200, 'should return 200');
+      test.equal(body, 'Hello from port ' + PORT, 'should return a dynamic response');
+      get({
+        hostname: 'localhost',
+        port: PORT,
+        path: '/fixtures/hello.txt',
+        headers: {
+          accept: 'text/plain',
+        },
+      }, function(res, body) {
+        test.equal(res.statusCode, 200, 'should return 200');
+        test.equal(body, 'Hello world', 'should return static page');
+        test.done();
+      });
+    });
+  },
+  null_middleware_should_use_default_middleware: function(test) {
+    test.expect(2);
+    get({
+      hostname: 'localhost',
+      port: 8008,
+      path: '/fixtures/hello.txt',
+      headers: {
+        accept: 'text/plain',
+      },
+    }, function(res, body) {
+      test.equal(res.statusCode, 200, 'should return 200');
+      test.equal(body, 'Hello world', 'should return static page');
+      test.done();
+    });
+  },
+  empty_middleware_should_404_everything: function(test) {
+    test.expect(1);
+    get({
+      hostname: 'localhost',
+      port: 8009,
+      path: '/fixtures/hello.txt',
+      headers: {
+        accept: 'text/plain',
+      },
+    }, function(res, body) {
+      test.equal(res.statusCode, 404, 'should return 404');
+      test.done();
+    });
+  },
+  custom_middleware_can_patch_default_middleware: function(test) {
+    var PORT = 8010;
+    test.expect(4);
+    get({
+      hostname: 'localhost',
+      port: PORT,
+      path: '/hello/world',
+      headers: {
+        accept: 'text/plain',
+      },
+      middleware: []
+    }, function(res, body) {
+      test.equal(res.statusCode, 200, 'should return 200');
+      test.equal(body, 'Hello, world from port #' + PORT + '!', 'should return a dynamic response');
+
+      get({
+        hostname: 'localhost',
+        port: PORT,
+        path: '/fixtures/hello.txt',
+        headers: {
+          accept: 'text/plain',
+        },
+      }, function(res, body) {
+        test.equal(res.statusCode, 200, 'should return 200');
+        test.equal(body, 'Hello world', 'should return static page');
+        test.done();
+      });
     });
   },
 };


### PR DESCRIPTION
Hi,

I'm the author of a developer utility called [json-proxy](steve-jansen/json-proxy) and love grunt!  I noticed recently my documentation for injecting json-proxy as middleware into grunt-contrib-connect no longer worked properly with Yeoman.io templates.

I realized that users are copying the default middlewares function from [connect.js#L31-45](https://github.com/gruntjs/grunt-contrib-connect/blob/master/tasks/connect.js#L31-45).

This seems really fragile, and awkward for users. See https://github.com/drewzboto/grunt-connect-proxy/issues/29 as an example.

So, I enhanced the `options.middleware` logic to maintain backwards compatibility yet make life easier for extending the default middlewares:
- modified options.middleware to accept an array or a function
- modified the arguments sent to the options.middleware function to include a third argument that is the array of default middlewares

I included passing nodeunit tests and updated the relevant docs.  I also refactored the tests to include coverage for HTTPS use cases (which I believe other PRs may address as well; figured it was worth fixing while I was in the codebase).  Finally, I reconfigured the test cases to use a sequential set of ports starting at TCP port 8000.

Enjoy!
Steve
