### PR TITLE
User can choose browser to launch site in

### DIFF
--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -157,14 +157,14 @@ module.exports = function(grunt) {
               grunt.event.emit('connect.' + taskTarget + '.listening', hostname, address.port);
 
               if (options.open === true) {
-                open(target);
+                open(target, options.browser || void 0);
               } else if (typeof options.open === 'object') {
                 options.open.target = options.open.target || target;
                 options.open.appName = options.open.appName || null;
                 options.open.callback = options.open.callback || function() {};
                 open(options.open.target, options.open.appName, options.open.callback);
               } else if (typeof options.open === 'string') {
-                open(options.open);
+                open(options.open, options.browser || void 0);
               }
 
               if (!keepAlive) {


### PR DESCRIPTION
User can add a browser option. To test in Mac, add `browser: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'` to your connect.livereload.options. Now your site will launch in Chrome, rather than Safari (the default).
