### PR TITLE
Adds onCreateServer option, to access connect's server object directly.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -144,6 +144,18 @@ module.exports = function(grunt) {
           hostname: '*',
           base: 'test/'
         }
+      },
+      onCreateServer: {
+        options: {
+          port: 8013,
+          hostname: '*',
+          onCreateServer: function(server, connect, options) {
+            server.on('request', function(req, res) {
+              // set a config object, so we can check it in our tests
+              grunt.config.data.connect.onCreateServer.test = true;
+            });
+          }
+        }
       }
     },
   });

--- a/README.md
+++ b/README.md
@@ -106,6 +106,31 @@ Open the served page in your default browser. Specifying `true` opens the defaul
 
 If `true` the task will look for the next available port after the set `port` option.
 
+#### onCreateServer
+Type: `Function` or `Array`
+Default: `null`
+
+A function to be called after the server object is created, to allow integrating libraries that need access to connect's server object. A Socket.IO example:
+
+```js
+grunt.initConfig({
+  connect: {
+    server: {
+      options: {
+        port: 8000,
+        hostname: '*',
+        onCreateServer: function(server, connect, options) {
+          var io = require('socket.io').listen(server);
+          io.sockets.on('connection', function(socket) {
+            // do something with socket
+          });
+        });
+      }
+    }
+  }
+});
+```
+
 #### middleware
 Type: `Function` or `Array`
 Default: `Array` of connect middlewares that use `options.base` for static files and directory browsing

--- a/docs/connect-options.md
+++ b/docs/connect-options.md
@@ -76,6 +76,31 @@ Open the served page in your default browser. Specifying `true` opens the defaul
 
 If `true` the task will look for the next available port after the set `port` option.
 
+## onCreateServer
+Type: `Function` or `Array`
+Default: `null`
+
+A function to be called after the server object is created, to allow integrating libraries that need access to connect's server object. A Socket.IO example:
+
+```js
+grunt.initConfig({
+  connect: {
+    server: {
+      options: {
+        port: 8000,
+        hostname: '*',
+        onCreateServer: function(server, connect, options) {
+          var io = require('socket.io').listen(server);
+          io.sockets.on('connection', function(socket) {
+            // do something with socket
+          });
+        });
+      }
+    }
+  }
+});
+```
+
 ## middleware
 Type: `Function` or `Array`
 Default: `Array` of connect middlewares that use `options.base` for static files and directory browsing

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -49,6 +49,7 @@ module.exports = function(grunt) {
       livereload: false,
       open: false,
       useAvailablePort: false,
+      onCreateServer: null,
       // if nothing passed, then is set below 'middleware = createDefaultMiddleware.call(this, connect, options);'
       middleware: null
     });
@@ -74,6 +75,10 @@ module.exports = function(grunt) {
     // Connect will listen to ephemeral port if asked
     if (options.port === '?') {
       options.port = 0;
+    }
+
+    if (options.onCreateServer && !Array.isArray(options.onCreateServer)) {
+      options.onCreateServer = [options.onCreateServer];
     }
 
     //  The middleware options may be null, an array of middleware objects,
@@ -135,6 +140,13 @@ module.exports = function(grunt) {
           }, app);
         } else {
           server = http.createServer(app);
+        }
+
+        // Call any onCreateServer functions that are present
+        if (options.onCreateServer) {
+          options.onCreateServer.forEach(function(func) {
+            func.call(null, server, connect, options);
+          });
         }
 
         portscanner.findAPortNotInUse(options.port, options.port + MAX_PORTS, options.hostname, function(error, foundPort) {

--- a/test/connect_test.js
+++ b/test/connect_test.js
@@ -251,4 +251,12 @@ exports.connect = {
       });
     });
   },
+  onCreateServer: function(test) {
+		test.expect(1);
+
+    get('http://localhost:8013/hello', function(res, body) {
+      test.ok(grunt.config.data.connect.onCreateServer.test, 'should set configuration object on request');
+      test.done();
+    });
+  }
 };


### PR DESCRIPTION
Adds an onCreateServer option, which is a function or an array of functions to be called just after `http.createServer()` is called. This allows libraries—such as [Socket.IO](http://socket.io)—which need access to the server object to be used with grunt-contrib-connect.
