### PR TITLE
Fix syntax error in onCreateMaster option example.

### DIFF
--- a/docs/connect-options.md
+++ b/docs/connect-options.md
@@ -94,7 +94,7 @@ grunt.initConfig({
           io.sockets.on('connection', function(socket) {
             // do something with socket
           });
-        });
+        }
       }
     }
   }


### PR DESCRIPTION
This is the correct fix for #105, so a future run of `grunt` doesn't overwrite the updated docs.
