### PR TITLE
Bump connect-livereload dependency to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "connect": "~2.13.0",
-    "connect-livereload": "~0.3.0",
+    "connect-livereload": "~0.4.0",
     "open": "0.0.4",
     "portscanner": "0.2.2",
     "async": "~0.2.10"


### PR DESCRIPTION
This fixes an issue where the livereload snippet gets inserted at the wrong place
when there are several bodies present, e.g. when using an iframe
