### PR TITLE
Added a disconnect command which allows grunt to close the server

### DIFF
--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -167,7 +167,7 @@ module.exports = function(grunt) {
             grunt.fatal('Port ' + options.port + ' is already in use by another process.');
           }
 
-          server
+          var instance = server
             .listen(foundPort, options.hostname)
             .on('listening', function() {
               var address = server.address();
@@ -204,6 +204,10 @@ module.exports = function(grunt) {
             });
         });
 
+        grunt.config('connect.' + taskTarget + '.server-closer', function(cb) {
+          instance.close(cb);
+        });
+
         // So many people expect this task to keep alive that I'm adding an option
         // for it. Running the task explicitly as grunt:keepalive will override any
         // value stored in the config. Have fun, people.
@@ -214,5 +218,14 @@ module.exports = function(grunt) {
         }
       }
     ]);
+  });
+
+  grunt.registerTask('disconnect', 'Stop a connected web server.', function(target) {
+    var stopServer = grunt.config('connect.' + target + '.server-closer'),
+        done = this.async();
+
+    if (stopServer) { stopServer(done); }
+
+    grunt.config('connect.' + target + '.server-closer', undefined)
   });
 };


### PR DESCRIPTION
Related to issue https://github.com/gruntjs/grunt-contrib-connect/issues/83 this is an initial thought on how this could be accomplished.

This works for me, but I don't know how to write tests for it (i.e. I could use some help writing a test for this)
