### PR TITLE
FIXED: middleware example, see issue ##114

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ grunt.initConfig({
       options: {
         middleware: function(connect, options, middlewares) {
           // inject a custom middleware into the array of default middlewares
-          middlewares.push(function(req, res, next) {
+          middlewares.unshift(function(req, res, next) {
             if (req.url !== '/hello/world') return next();
 
             res.end('Hello, world from port #' + options.port + '!');


### PR DESCRIPTION
Replaced middlewares.push() with middlewares.unshift() since with push() the middleware won't run at all.
