### PR TITLE
Routable middleware

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -198,6 +198,18 @@ module.exports = function(grunt) {
             });
           }
         }
+      },
+      routedMiddleware: {
+        options: {
+          port: 8016,
+          hostname: '*',
+          middleware: function(connect, options, middleware) {
+            middleware.unshift(['/mung', function (req, res, next) {
+              res.end('Yay');
+            }]);
+            return middleware;
+          }
+        }
       }
     },
   });

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -17,6 +17,7 @@ module.exports = function(grunt) {
   var open = require('opn');
   var portscanner = require('portscanner');
   var async = require('async');
+  var util = require('util');
 
   var MAX_PORTS = 30; // Maximum available ports to check after the specified port
 
@@ -140,8 +141,15 @@ module.exports = function(grunt) {
       },
       function(){
 
-        var app = connect.apply(null, middleware);
+        var app = connect();
         var server = null;
+
+        middleware.forEach(function (m) {
+          if (!util.isArray(m)) {
+            m = [m];
+          }
+          app.use.apply(app, m);
+        });
 
         if (options.protocol === 'https') {
           server = https.createServer({

--- a/test/connect_test.js
+++ b/test/connect_test.js
@@ -295,5 +295,13 @@ exports.connect = {
       test.ok(grunt.config.data.connect.onCreateServer.test, 'should set configuration object on request');
       test.done();
     });
+  },
+  routedMiddleware: function(test) {
+    test.expect(1);
+
+    get('http://localhost:8016/mung', function(res, body) {
+      test.equal(body, 'Yay', 'should return a string at /mung');
+      test.done();
+    });
   }
 };


### PR DESCRIPTION
Added option to have routed middleware by using an array. The 1st
argument is the route, the second is the handler.

``` js
connect: {
  options: {
    middlware: [
      ['/routable-middleware', function (req, res) {
        res.end('I\'ll only run on "/routable-middleware"');
      }]
    ]
  }
}
```
