### PR TITLE
Run jshint only once upon `npm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "test": "grunt jshint test"
+    "test": "grunt test"
   },
   "dependencies": {
     "async": "~0.9.0",


### PR DESCRIPTION
Addition to https://github.com/gruntjs/grunt-contrib-connect/pull/129.
