### PR TITLE
Correct keepalive option without a target

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ grunt.loadNpmTasks('grunt-contrib-connect');
 ## Connect task
 _Run this task with the `grunt connect` command._
 
-Note that this server only runs as long as grunt is running. Once grunt's tasks have completed, the web server stops. This behavior can be changed with the [keepalive](#keepalive) option, and can be enabled ad-hoc by running the task like `grunt connect:keepalive`.
+Note that this server only runs as long as grunt is running. Once grunt's tasks have completed, the web server stops. This behavior can be changed with the [keepalive](#keepalive) option, and can be enabled ad-hoc by running the task like `grunt connect::keepalive`.
 
 This task was designed to be used in conjunction with another task that is run immediately afterwards, like the [grunt-contrib-qunit plugin](https://github.com/gruntjs/grunt-contrib-qunit) `qunit` task.
 ### Options


### PR DESCRIPTION
If running without a target you need to use 2 colons so it doesn't think keepalive is a target.
This confused me for couple of minutes so thought I'd fix...
