### PR TITLE
Added event to notify other grunt plugins that connect has been started.

### DIFF
--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -220,6 +220,8 @@ module.exports = function(grunt) {
           // function, this task will never, ever, ever terminate. Have fun!
           grunt.log.write('Waiting forever...\n');
         }
+
+        grunt.event.emit('connect-started', server, options.port);
       }
     ]);
   });


### PR DESCRIPTION
I have added a grunt.event.emit so that other grunt plugins can be notified of the connect startup. I require this functionality for my grunt-websocket plugin so that it can bind itself to the connect http server so that both websocket and http can be served from one port (80) instead of having a different port for my websocket server. This way it would be more proxy and NAT friendly. I kindly ask you to add this to the main repo as this might be useful for other plugins aswel.
