### PR TITLE
define module entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "name": "Grunt Team",
     "url": "http://gruntjs.com/"
   },
+  "main": "tasks/connect.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/gruntjs/grunt-contrib-connect.git"


### PR DESCRIPTION
### Problem
We are writing a Grunt plugin using grunt-contrib-connect (and other plugins) in order to preconfigure them. We load the different modules using the node `require` method. Because the entry point of grunt-contrib-connect is not defined, we have to load it this way: `require(require-contrib-connect/tasks/connect.js)`. We have to know the structure of the module in order to load it.

### Solution
The solution is to define the module entry point in the package.json:
`"main": "tasks/connect.js"`
 Then we can load module in a better way:
`require('grunt-contrib-connect')`.