### PR TITLE
Give hostname default more clarity for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Default: `'0.0.0.0'`
 
 The hostname the webserver will use.
 
-Setting it to `'*'` will make the server accessible from anywhere.
+Setting it to `'*'`, like '`0.0.0.0`', will make the server accessible from any **local** IPv4 address like  `'127.0.0.1'` and the IP assigned to an ethernet or wireless interface (like `'192.168.0.x'` or `'10.0.0.x'`). [More info](http://en.wikipedia.org/wiki/0.0.0.0)
 
 #### base
 Type: `String` or `Array` or `Object`  


### PR DESCRIPTION
For new web developers it can be not clear that 0.0.0.0 can be accessed from any IPv4 address for their system like the 127.0.0.1 loopback.

This is in response to https://github.com/gruntjs/grunt-contrib-connect/issues/164 to help inform developers so that the current default can remain useful to all developers.