### PR TITLE
Use 'localhost' instead of '0.0.0.0' in target URL

### DIFF
--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -180,7 +180,8 @@ module.exports = function(grunt) {
             .on('listening', function() {
               var address = server.address();
               var hostname = options.hostname || '0.0.0.0';
-              var target = options.protocol + '://' + hostname + ':' + address.port;
+              var targetHostname = (hostname === '0.0.0.0' ? 'localhost' : hostname);
+              var target = options.protocol + '://' + targetHostname + ':' + address.port;
 
               grunt.log.writeln('Started connect web server on ' + target);
               grunt.config.set('connect.' + taskTarget + '.options.hostname', hostname);


### PR DESCRIPTION
http://0.0.0.0/ is not a routable address, according to https://code.google.com/p/chromium/issues/detail?id=428046.

This was causing problems when using the combination of '{ hostname: "*", open: true }' with newer versions of Chrome.