### PR TITLE
Fix indent style in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,8 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
According to http://gruntjs.com/contributing#syntax, indents should use two spaces