### PR TITLE
Log errors from portscanner

### DIFF
--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -180,6 +180,10 @@ module.exports = function(grunt) {
         }
 
         findUnusedPort(options.port, options.port + MAX_PORTS, options.hostname, function(error, foundPort) {
+          if (error) {
+            grunt.log.writeln('Failed to find unused port: ' + error);
+          }
+          
           // if the found port doesn't match the option port, and we are forced to use the option port
           if (options.port !== foundPort && options.useAvailablePort === false) {
             grunt.fatal('Port ' + options.port + ' is already in use by another process.');

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -170,6 +170,10 @@ module.exports = function(grunt) {
         }
 
         function findUnusedPort(port, maxPort, hostname, callback) {
+          if (hostname === '0.0.0.0') {
+            hostname = '127.0.0.1';
+          }
+          
           if (port === 0) {
             async.nextTick(function() {
               callback(null, 0);


### PR DESCRIPTION
e.g. EADDRNOTAVAIL might be thrown if the `hostname` is invalid.

We might even do a `grunt.fatal`, but I'm not sure.

I added a second fix in this patch because the first commit failed the build: If `hostname` is set to `0.0.0.0`, grunt tries to do the port scan on this ip, which obviously fails. I added a rule to rewrite `0.0.0.0` to `127.0.0.1`.