### PR TITLE
Fixing debug logging.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "async": "^0.9.0",
     "connect": "^3.4.0",
     "connect-livereload": "^0.5.0",
+    "morgan": "^1.6.1",
     "opn": "^1.0.0",
     "portscanner": "^1.0.0",
     "serve-index": "^1.7.1",

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -11,6 +11,7 @@
 module.exports = function(grunt) {
   var path = require('path');
   var connect = require('connect');
+  var morgan = require('morgan');
   var serveStatic = require('serve-static');
   var serveIndex = require('serve-index');
   var http = require('http');
@@ -115,9 +116,9 @@ module.exports = function(grunt) {
 
     // If --debug was specified, enable logging.
     if (grunt.option('debug') || options.debug === true) {
-      connect.logger.format('grunt', ('[D] server :method :url :status ' +
+      morgan.format('grunt', ('[D] server :method :url :status ' +
         ':res[content-length] - :response-time ms').magenta);
-      middleware.unshift(connect.logger('grunt'));
+      middleware.unshift(morgan('grunt'));
     }
 
     // Start server.


### PR DESCRIPTION
Logging (when using the `--debug` flag) has been broken since upgrading to Connect 3.x, because they removed connect.logger.  The following error message causes Grunt to abort operations whenever using `--debug`:

`Warning: Cannot read property 'format' of undefined Use --force to continue.`

The logger middleware is now extracted into its own module called morgan.

This patch updates grunt-contrib-connect to use morgan.