### PR TITLE
Implemented http2 protocol support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -217,6 +217,13 @@ module.exports = function(grunt) {
             return middleware;
           }
         }
+      },
+      http2: {
+        options: {
+          base: 'test',
+          port: 8017,
+          protocol: 'https'
+        }
       }
     }
   });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,208 @@ var serveStatic = require('serve-static');
 var certs = path.join(__dirname, 'tasks', 'certs');
 
 module.exports = function(grunt) {
+  var testConnectInstances = {
+    basic: {
+      options: {
+        port: 7999
+      }
+    },
+    custom_base: {
+      options: {
+        base: 'test'
+      }
+    },
+    custom_port: {
+      options: {
+        base: 'test',
+        port: 8001
+      }
+    },
+    self_port_q: {
+      options: {
+        base: 'test',
+        port: '?'
+      }
+    },
+    self_port_0: {
+      options: {
+        base: 'test',
+        port: 0
+      }
+    },
+    custom_https: {
+      options: {
+        base: 'test',
+        port: 8002,
+        protocol: 'https'
+      }
+    },
+    custom_https_certs: {
+      options: {
+        base: 'test',
+        port: 8003,
+        protocol: 'https',
+        key: grunt.file.read(path.join(certs, 'server.key')).toString(),
+        cert: grunt.file.read(path.join(certs, 'server.crt')).toString(),
+        ca: grunt.file.read(path.join(certs, 'ca.crt')).toString(),
+        passphrase: ''
+      }
+    },
+    custom_base_with_options: {
+      options: {
+        base: {
+          path: 'test',
+          options: {
+            index: 'fixtures/hello.txt'
+          }
+        },
+        port: 8014
+      }
+    },
+    multiple_base: {
+      options: {
+        base: ['test', 'docs'],
+        port: 8004
+      }
+    },
+    multiple_base_with_options: {
+      options: {
+        base: [
+          {
+            path: 'test',
+            options: {
+              index: 'fixtures/hello.txt'
+            }
+          },
+          {
+            path: 'docs',
+            options: {
+              maxAge: 300000 // 5min
+            }
+          }
+        ],
+        port: 8015
+      }
+    },
+    multiple_base_directory: {
+      options: {
+        base: ['test', 'docs'],
+        directory: 'test/fixtures/',
+        port: 8005
+      }
+    },
+    livereload: {
+      options: {
+        livereload: true,
+        base: 'test/fixtures/',
+        port: 8006
+      }
+    },
+    custom_middleware: {
+      options: {
+        port: 8007,
+        base: 'test',
+        middleware: function(connect, options, middlwares) {
+          // an explicit array of any middlewares that ignores the default set
+          return [
+            serveStatic(options.base[0]),
+  
+            function(req, res, next) {
+              if (req.url !== '/hello/world') {
+                next();
+                return;
+              }
+              res.end('Hello from port ' + options.port);
+            }
+          ];
+        }
+      }
+    },
+    null_middleware: {
+      options: {
+        port: 8008,
+        base: 'test/',
+        middleware: null
+      }
+    },
+    empty_middleware: {
+      options: {
+        port: 8009,
+        base: 'test/',
+        middleware: []
+      }
+    },
+    custom_middleware_patch_default_middleware: {
+      options: {
+        port: 8010,
+        base: 'test/',
+        middleware: function(connect, options, middlewares) {
+          // inject a custom middleware into the array of default middlewares
+          // this is likely the easiest way for other grunt plugins to
+          // extend the behavior of grunt-contrib-connect
+          middlewares.unshift(function(req, res, next) {
+            if (req.url !== '/hello/world') {
+              return next();
+            }
+  
+            res.end('Hello, world from port #' + options.port + '!');
+          });
+  
+          return middlewares;
+        }
+      }
+    },
+    useAvailablePort: {
+      options: {
+        port: 8011,
+        useAvailablePort: true,
+        livereload: true
+      }
+    },
+    allHostname: {
+      options: {
+        port: 8012,
+        hostname: '*',
+        base: 'test/'
+      }
+    },
+    onCreateServer: {
+      options: {
+        port: 8013,
+        hostname: '*',
+        onCreateServer: function(server, connect, options) {
+          server.on('request', function(req, res) {
+            // set a config object, so we can check it in our tests
+            grunt.config.data.connect.onCreateServer.test = true;
+          });
+        }
+      }
+    },
+    routedMiddleware: {
+      options: {
+        port: 8016,
+        hostname: '*',
+        middleware: function(connect, options, middleware) {
+          middleware.unshift(['/mung', function (req, res, next) {
+            res.end('Yay');
+          }]);
+          return middleware;
+        }
+      }
+    }
+  };
+  
+  // don't try to test http2 support in node < 0.12, see https://github.com/molnarg/node-http2/issues/101
+  if (!/^0.(?:1|2|3|4|5|6|7|8|9|10|11)\./.test(process.versions.node)) {
+    testConnectInstances.http2 = {
+      options: {
+        base: 'test',
+        port: 8017,
+        protocol: 'http2', 
+      }
+    };
+  }
+  
   grunt.initConfig({
     jshint: {
       all: [
@@ -29,203 +231,7 @@ module.exports = function(grunt) {
       tests: ['test/*_test.js']
     },
 
-    connect: {
-      basic: {
-        options: {
-          port: 7999
-        }
-      },
-      custom_base: {
-        options: {
-          base: 'test'
-        }
-      },
-      custom_port: {
-        options: {
-          base: 'test',
-          port: 8001
-        }
-      },
-      self_port_q: {
-        options: {
-          base: 'test',
-          port: '?'
-        }
-      },
-      self_port_0: {
-        options: {
-          base: 'test',
-          port: 0
-        }
-      },
-      custom_https: {
-        options: {
-          base: 'test',
-          port: 8002,
-          protocol: 'https'
-        }
-      },
-      custom_https_certs: {
-        options: {
-          base: 'test',
-          port: 8003,
-          protocol: 'https',
-          key: grunt.file.read(path.join(certs, 'server.key')).toString(),
-          cert: grunt.file.read(path.join(certs, 'server.crt')).toString(),
-          ca: grunt.file.read(path.join(certs, 'ca.crt')).toString(),
-          passphrase: ''
-        }
-      },
-      custom_base_with_options: {
-        options: {
-          base: {
-            path: 'test',
-            options: {
-              index: 'fixtures/hello.txt'
-            }
-          },
-          port: 8014
-        }
-      },
-      multiple_base: {
-        options: {
-          base: ['test', 'docs'],
-          port: 8004
-        }
-      },
-      multiple_base_with_options: {
-        options: {
-          base: [
-            {
-              path: 'test',
-              options: {
-                index: 'fixtures/hello.txt'
-              }
-            },
-            {
-              path: 'docs',
-              options: {
-                maxAge: 300000 // 5min
-              }
-            }
-          ],
-          port: 8015
-        }
-      },
-      multiple_base_directory: {
-        options: {
-          base: ['test', 'docs'],
-          directory: 'test/fixtures/',
-          port: 8005
-        }
-      },
-      livereload: {
-        options: {
-          livereload: true,
-          base: 'test/fixtures/',
-          port: 8006
-        }
-      },
-      custom_middleware: {
-        options: {
-          port: 8007,
-          base: 'test',
-          middleware: function(connect, options, middlwares) {
-            // an explicit array of any middlewares that ignores the default set
-            return [
-              serveStatic(options.base[0]),
-
-              function(req, res, next) {
-                if (req.url !== '/hello/world') {
-                  next();
-                  return;
-                }
-                res.end('Hello from port ' + options.port);
-              }
-            ];
-          }
-        }
-      },
-      null_middleware: {
-        options: {
-          port: 8008,
-          base: 'test/',
-          middleware: null
-        }
-      },
-      empty_middleware: {
-        options: {
-          port: 8009,
-          base: 'test/',
-          middleware: []
-        }
-      },
-      custom_middleware_patch_default_middleware: {
-        options: {
-          port: 8010,
-          base: 'test/',
-          middleware: function(connect, options, middlewares) {
-            // inject a custom middleware into the array of default middlewares
-            // this is likely the easiest way for other grunt plugins to
-            // extend the behavior of grunt-contrib-connect
-            middlewares.unshift(function(req, res, next) {
-              if (req.url !== '/hello/world') {
-                return next();
-              }
-
-              res.end('Hello, world from port #' + options.port + '!');
-            });
-
-            return middlewares;
-          }
-        }
-      },
-      useAvailablePort: {
-        options: {
-          port: 8011,
-          useAvailablePort: true,
-          livereload: true
-        }
-      },
-      allHostname: {
-        options: {
-          port: 8012,
-          hostname: '*',
-          base: 'test/'
-        }
-      },
-      onCreateServer: {
-        options: {
-          port: 8013,
-          hostname: '*',
-          onCreateServer: function(server, connect, options) {
-            server.on('request', function(req, res) {
-              // set a config object, so we can check it in our tests
-              grunt.config.data.connect.onCreateServer.test = true;
-            });
-          }
-        }
-      },
-      routedMiddleware: {
-        options: {
-          port: 8016,
-          hostname: '*',
-          middleware: function(connect, options, middleware) {
-            middleware.unshift(['/mung', function (req, res, next) {
-              res.end('Yay');
-            }]);
-            return middleware;
-          }
-        }
-      },
-      http2: {
-        options: {
-          base: 'test',
-          port: 8017,
-          protocol: 'http2'
-        }
-      }
-    }
+    connect: testConnectInstances
   });
 
   grunt.loadTasks('tasks');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -222,7 +222,7 @@ module.exports = function(grunt) {
         options: {
           base: 'test',
           port: 8017,
-          protocol: 'https'
+          protocol: 'http2'
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The port on which the webserver will respond. The task will fail if the specifie
 Type: `String`  
 Default: `'http'`
 
-May be `'http'` or `'https'`.
+May be `'http'`, `'https'` or `'http2'`.
 
 #### hostname
 Type: `String`  
@@ -295,10 +295,10 @@ grunt.registerTask('connect', 'Start a custom static web server.', function() {
 });
 ```
 
-#### Support for HTTPS
+#### Support for HTTPS / HTTP2
 
 A default certificate authority, certificate and key file are provided and pre-
-configured for use when `protocol` has been set to `https`.
+configured for use when `protocol` has been set to `https` or `http2`.
 
 NOTE: No passphrase set for the certificate.
 If you are getting warnings in Google Chrome, add 'server.crt' (from 'node_modules/tasks/certs')
@@ -309,7 +309,7 @@ select 'Get Info' - 'Trust' - 'Always Trust', close window, restart Chrome.
 For HTTPS livereload with [grunt-contrib-watch](https://github.com/gruntjs/grunt-contrib-watch) 
  see the last example [here](https://github.com/gruntjs/grunt-contrib-watch#optionslivereload).
 
-###### Advanced HTTPS config
+###### Advanced HTTPS / HTTP2 config
 
 If the default certificate setup is unsuitable for your environment, OpenSSL
 can be used to create a set of self-signed certificates with a local ca root.
@@ -344,7 +344,7 @@ grunt.initConfig({
   connect: {
     server: {
       options: {
-        protocol: 'https',
+        protocol: 'https', // or 'http2'
         port: 8443,
         key: grunt.file.read('server.key').toString(),
         cert: grunt.file.read('server.crt').toString(),

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "async": "^0.9.0",
     "connect": "^3.4.0",
     "connect-livereload": "^0.5.0",
+    "http2": "^3.3.2",
     "morgan": "^1.6.1",
     "opn": "^1.0.0",
     "portscanner": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "async": "^0.9.0",
     "connect": "^3.4.0",
     "connect-livereload": "^0.5.0",
-    "http2": "^3.3.2",
+    "http2": "github:gruntjs/node-http2#fix-return-value",
     "morgan": "^1.6.1",
     "opn": "^1.0.0",
     "portscanner": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": "gruntjs/grunt-contrib-connect",
   "license": "MIT",
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=0.10.0"
   },
   "scripts": {
     "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "async": "^0.9.0",
     "connect": "^3.4.0",
     "connect-livereload": "^0.5.0",
-    "http2": "github:gruntjs/node-http2#fix-return-value",
+    "http2": "git://github.com/gruntjs/node-http2#fix-return-value",
     "morgan": "^1.6.1",
     "opn": "^1.0.0",
     "portscanner": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": "gruntjs/grunt-contrib-connect",
   "license": "MIT",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.12.0"
   },
   "scripts": {
     "test": "grunt test"

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -66,6 +66,10 @@ module.exports = function(grunt) {
     if (options.protocol !== 'http' && options.protocol !== 'https' && options.protocol !== 'http2') {
       grunt.fatal('protocol option must be \'http\', \'https\' or \'http2\'');
     }
+    
+    if (options.protocol === 'http2' && /^0.(?:1|2|3|4|5|6|7|8|9|10|11)\./.test(process.versions.node)) {
+      grunt.fatal('can\'t use http2 with node < 0.12, see https://github.com/molnarg/node-http2/issues/101');
+    }
 
     // Connect requires the base path to be absolute.
     if (Array.isArray(options.base)) {

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -16,6 +16,7 @@ module.exports = function(grunt) {
   var serveIndex = require('serve-index');
   var http = require('http');
   var https = require('https');
+  var http2 = require('http2');
   var injectLiveReload = require('connect-livereload');
   var open = require('opn');
   var portscanner = require('portscanner');
@@ -62,8 +63,8 @@ module.exports = function(grunt) {
       middleware: null
     });
 
-    if (options.protocol !== 'http' && options.protocol !== 'https') {
-      grunt.fatal('protocol option must be \'http\' or \'https\'');
+    if (options.protocol !== 'http' && options.protocol !== 'https' && options.protocol !== 'http2') {
+      grunt.fatal('protocol option must be \'http\', \'https\' or \'http2\'');
     }
 
     // Connect requires the base path to be absolute.
@@ -146,6 +147,12 @@ module.exports = function(grunt) {
 
         var app = connect();
         var server = null;
+        var httpsOptions = {
+          key: options.key || grunt.file.read(path.join(__dirname, 'certs', 'server.key')).toString(),
+          cert: options.cert || grunt.file.read(path.join(__dirname, 'certs', 'server.crt')).toString(),
+          ca: options.ca || grunt.file.read(path.join(__dirname, 'certs', 'ca.crt')).toString(),
+          passphrase: options.passphrase || 'grunt'
+        };
 
         middleware.forEach(function (m) {
           if (!util.isArray(m)) {
@@ -155,12 +162,9 @@ module.exports = function(grunt) {
         });
 
         if (options.protocol === 'https') {
-          server = https.createServer({
-            key: options.key || grunt.file.read(path.join(__dirname, 'certs', 'server.key')).toString(),
-            cert: options.cert || grunt.file.read(path.join(__dirname, 'certs', 'server.crt')).toString(),
-            ca: options.ca || grunt.file.read(path.join(__dirname, 'certs', 'ca.crt')).toString(),
-            passphrase: options.passphrase || 'grunt'
-          }, app);
+          server = https.createServer(httpsOptions, app);
+        } else if (options.protocol === 'http2') {
+          server = http2.createServer(httpsOptions, app);
         } else {
           server = http.createServer(app);
         }
@@ -199,16 +203,17 @@ module.exports = function(grunt) {
           server
             .listen(foundPort, options.hostname)
             .on('listening', function() {
-              var address = server.address();
+              var port = foundPort;
+              var scheme = options.protocol === 'http2' ? 'https' : options.protocol;
               var hostname = options.hostname || '0.0.0.0';
               var targetHostname = hostname === '0.0.0.0' ? 'localhost' : hostname;
-              var target = options.protocol + '://' + targetHostname + ':' + address.port;
+              var target = scheme + '://' + targetHostname + ':' + port;
 
               grunt.log.writeln('Started connect web server on ' + target);
               grunt.config.set('connect.' + taskTarget + '.options.hostname', hostname);
-              grunt.config.set('connect.' + taskTarget + '.options.port', address.port);
+              grunt.config.set('connect.' + taskTarget + '.options.port', port);
 
-              grunt.event.emit('connect.' + taskTarget + '.listening', hostname, address.port);
+              grunt.event.emit('connect.' + taskTarget + '.listening', hostname, port);
 
               if (options.open === true) {
                 open(target);

--- a/test/connect_test.js
+++ b/test/connect_test.js
@@ -3,10 +3,15 @@
 var grunt = require('grunt');
 var http = require('http');
 var https = require('https');
+var http2 = require('http2');
 
 function get(url, done) {
   var client = http;
-  if (typeof url === 'string' && url.toLowerCase().indexOf('https') === 0 ||
+  if (typeof url === 'object' && url.scheme === 'http2') {
+    client = http2;
+    delete url.scheme;
+  }
+  else if (typeof url === 'string' && url.toLowerCase().indexOf('https') === 0 ||
     typeof url === 'object' && url.port === 443 ||
     typeof url === 'object' && url.scheme === 'https') {
     client = https;
@@ -48,6 +53,24 @@ exports.connect = {
         accept: 'text/plain'
       }
     }, function(res, body) {
+      test.equal(res.statusCode, 200, 'should return 200');
+      test.equal(body, 'Hello world', 'should return static page');
+      test.done();
+    });
+  },
+  custom_http2: function(test) {
+    test.expect(3);
+    get({
+      scheme: 'http2',
+      rejectUnauthorized: false,
+      hostname: 'localhost',
+      port: 8017,
+      path: '/fixtures/hello.txt',
+      headers: {
+        accept: 'text/plain'
+      }
+    }, function(res, body) {
+      test.equal(res.httpVersion, '2.0', 'should return HTTP/2 response');
       test.equal(res.statusCode, 200, 'should return 200');
       test.equal(body, 'Hello world', 'should return static page');
       test.done();
@@ -173,7 +196,7 @@ exports.connect = {
       }
     }, function(res, body) {
       test.ok(body.indexOf('35729/livereload.js') !== -1, 'Should contain livereload snippet.');
-
+  
       // check if livereload works with params
       get({
         hostname: 'localhost',
@@ -259,7 +282,7 @@ exports.connect = {
     }, function(res, body) {
       test.equal(res.statusCode, 200, 'should return 200');
       test.equal(body, 'Hello, world from port #' + PORT + '!', 'should return a dynamic response');
-
+  
       get({
         hostname: 'localhost',
         port: PORT,
@@ -276,7 +299,7 @@ exports.connect = {
   },
   allHostname: function(test) {
     test.expect(3);
-
+  
     get('http://localhost:8012/fixtures/hello.txt', function(res, body) {
       test.equal(res.statusCode, 200, 'should return 200');
       get('http://127.0.0.1:8012/fixtures/hello.txt', function(res, body) {
@@ -298,7 +321,7 @@ exports.connect = {
   },
   routedMiddleware: function(test) {
     test.expect(1);
-
+  
     get('http://localhost:8016/mung', function(res, body) {
       test.equal(body, 'Yay', 'should return a string at /mung');
       test.done();

--- a/test/connect_test.js
+++ b/test/connect_test.js
@@ -59,22 +59,27 @@ exports.connect = {
     });
   },
   custom_http2: function(test) {
-    test.expect(3);
-    get({
-      scheme: 'http2',
-      rejectUnauthorized: false,
-      hostname: 'localhost',
-      port: 8017,
-      path: '/fixtures/hello.txt',
-      headers: {
-        accept: 'text/plain'
-      }
-    }, function(res, body) {
-      test.equal(res.httpVersion, '2.0', 'should return HTTP/2 response');
-      test.equal(res.statusCode, 200, 'should return 200');
-      test.equal(body, 'Hello world', 'should return static page');
+    if (!grunt.config.data.connect.http2) {
       test.done();
-    });
+    }
+    else {
+      test.expect(3);
+      get({
+        scheme: 'http2',
+        rejectUnauthorized: false,
+        hostname: 'localhost',
+        port: 8017,
+        path: '/fixtures/hello.txt',
+        headers: {
+          accept: 'text/plain'
+        }
+      }, function(res, body) {
+        test.equal(res.httpVersion, '2.0', 'should return HTTP/2 response');
+        test.equal(res.statusCode, 200, 'should return 200');
+        test.equal(body, 'Hello world', 'should return static page');
+        test.done();
+      });
+    }   
   },
   custom_https: function(test) {
     test.expect(2);


### PR DESCRIPTION
I did the wiring between [node-http2](https://github.com/molnarg/node-http2) and grunt-contrib-connect, because I have the same need the author of #202 has.

Some comments / explanations regarding the PR:
* To keep the changes in `tasks/connect.js` small, it currently depends on [another PR I made for node-http2](https://github.com/molnarg/node-http2/pull/168). If this PR takes too long to be accepted or will not be accepted at all the changes in this PR are very small (the `server.listen().on().on()` must be changed to three single statements: `server.listen(); server.on(); server.on()`).
* Because node-http2 doesn't support the `server.address()` method yet (see molnarg/node-http2#157) I had to refactor a bit and removed the use of the function and replaced the result (from which only the port is used) with the `foundPort` variable which IMO has the same value and is in context anyway.
* I had to set the minimum node version to 0.12, because of molnarg/node-http2#101. If support for 0.10 is still important, I suggest to add a check for node < 0.12 and protocol http2 which results in an error.