### PR TITLE
Using a predefined logger format with colored http status

### DIFF
--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -121,9 +121,7 @@ module.exports = function(grunt) {
 
     // If --debug was specified, enable logging.
     if (grunt.option('debug') || options.debug === true) {
-      morgan.format('grunt', ('[D] server :method :url :status ' +
-        ':res[content-length] - :response-time ms').magenta);
-      middleware.unshift(morgan('grunt'));
+      middleware.unshift(morgan('dev'));
     }
 
     // Start server.


### PR DESCRIPTION
Instead of creating a custom logger format, wouldn't it be useful to use the ones from morgan ? Especially the 'dev' format since it has colored http status, which would be useful for debugging.