### PR TITLE
Passing an 'ignore' option to connect-livereload to address problems with binary downloads. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Setting it to `'*'`, like '`0.0.0.0`', will make the server accessible from any 
 
 If [`open`](#open) is set to `true`, the `hostname` setting will be used to generate the URL that is opened by the browser, defaulting to `localhost` if a wildcard hostname was specified.
 
+#### ignore
+Type: `Array`__
+
+An array of Strings or RegExps the served urls will be matched against and excluded live-reloading. This makes possible to workaround a problem with damaged binary data (in case there is no explicit e.g. .pdf in the url itself - see discussion here: https://github.com/gruntjs/grunt-contrib-connect/issues/142)
+The value is passed as-is to the underlying https://github.com/intesso/connect-livereload middleware and it is documented there.
+
 #### base
 Type: `String` or `Array` or `Object`  
 Default: `'.'`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Setting it to `'*'`, like '`0.0.0.0`', will make the server accessible from any 
 If [`open`](#open) is set to `true`, the `hostname` setting will be used to generate the URL that is opened by the browser, defaulting to `localhost` if a wildcard hostname was specified.
 
 #### ignore
-Type: `Array`__
+Type: `Array`
 
 An array of Strings or RegExps the served urls will be matched against and excluded live-reloading. This makes possible to workaround a problem with damaged binary data (in case there is no explicit e.g. .pdf in the url itself - see discussion here: https://github.com/gruntjs/grunt-contrib-connect/issues/142)
 The value is passed as-is to the underlying https://github.com/intesso/connect-livereload middleware and it is documented there.

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -139,7 +139,12 @@ module.exports = function(grunt) {
           }
 
           // TODO: Add custom ports here?
-          middleware.unshift(injectLiveReload({port: options.livereload, hostname: options.hostname}));
+          var liveReloadOpts = {port: options.livereload, hostname: options.hostname};
+          // pass the ignore options - to address a problem: https://github.com/intesso/connect-livereload/issues/39
+          if (options.ignore) {
+            liveReloadOpts.ignore = options.ignore;
+          }
+          middleware.unshift(injectLiveReload(liveReloadOpts));
           callback(null);
         } else {
           callback(null);


### PR DESCRIPTION
It is discussed more here: https://github.com/gruntjs/grunt-contrib-connect/issues/142.