### PR TITLE
Allow giving a full livereload config as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ Default: `false`
 Set the `debug` option to true to enable logging instead of using the `--debug` flag.
 
 #### livereload
-Type: `Boolean` or `Number`  
+Type: `Boolean` or `Number` or `Object`  
 Default: `false`
 
-Set to `true` or a port number to inject a live reload script tag into your page using [connect-livereload](https://github.com/intesso/connect-livereload).
+Set to `true`, a port number or a full livereload configuration to inject a live reload script tag into your page using [connect-livereload](https://github.com/intesso/connect-livereload).
 
 *This does not perform live reloading. It is intended to be used in tandem with grunt-contrib-watch or another task that will trigger a live reload server upon files changing.*
 

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -134,12 +134,15 @@ module.exports = function(grunt) {
 
         // Inject live reload snippet
         if (options.livereload !== false) {
-          if (options.livereload === true) {
-            options.livereload = 35729;
+          if (typeof options.livereload === 'object') {
+            middleware.unshift(injectLiveReload(options.livereload));
+          } else {
+            if (options.livereload === true) {
+              options.livereload = 35729;
+            }
+            // TODO: Add custom ports here?
+            middleware.unshift(injectLiveReload({port: options.livereload, hostname: options.hostname}));
           }
-
-          // TODO: Add custom ports here?
-          middleware.unshift(injectLiveReload({port: options.livereload, hostname: options.hostname}));
           callback(null);
         } else {
           callback(null);


### PR DESCRIPTION
It would allow setting a different hostname from the connect one for example.
