### PR TITLE
pass directory options to serve-index

### DIFF
--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
       middlewares.push(serveStatic(path, staticOptions));
     });
     // Make directory browse-able.
-    middlewares.push(serveIndex(directory.path || directory));
+    middlewares.push(serveIndex(directory.path || directory, directory.options));
     return middlewares;
   };
 


### PR DESCRIPTION
allows the following options:
```
 connect: {
      server: {
        options: {
          directory: {
            path: './',
            options: {
              icons: true,
            }
          }
        }
      }
```