### PR TITLE
Allow all configuration options of livereload to be passed through.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -120,6 +120,13 @@ module.exports = function(grunt) {
         port: 8018
       }
     },
+    livereload_general: {
+      options: {
+        livereload: {src: 'https://example.org:54321/livereload.js?snipver=1'},
+        base: 'test/fixtures/',
+        port: 8019
+      }
+    },
     custom_middleware: {
       options: {
         port: 8007,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -113,6 +113,13 @@ module.exports = function(grunt) {
         port: 8006
       }
     },
+    livereload_port: {
+      options: {
+        livereload: 12345,
+        base: 'test/fixtures/',
+        port: 8018
+      }
+    },
     custom_middleware: {
       options: {
         port: 8007,

--- a/docs/connect-options.md
+++ b/docs/connect-options.md
@@ -56,12 +56,14 @@ Default: `false`
 Set the `debug` option to true to enable logging instead of using the `--debug` flag.
 
 ## livereload
-Type: `Boolean` or `Number`  
+Type: `Boolean`, `Number`, or `Object`  
 Default: `false`
 
-Set to `true` or a port number to inject a live reload script tag into your page using [connect-livereload](https://github.com/intesso/connect-livereload).
+Set to anything but `false` to inject a live reload script tag into your page using [connect-livereload](https://github.com/intesso/connect-livereload).
 
-*This does not perform live reloading. It is intended to be used in tandem with grunt-contrib-watch or another task that will trigger a live reload server upon files changing.*
+If you set to `true`, defaults are used. If you set to a number, that number is used as a port number, together with the hostname you configured. If you set this to an object, that object is passed to `connect-livereload` unchanged as its configuration.
+
+*This does not by itself perform live reloading.* It is intended to be used in tandem with grunt-contrib-watch or another task that will trigger a live reload server upon files changing.
 
 ## open
 Type: `Boolean` or `String` or `Object`  

--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -135,11 +135,11 @@ module.exports = function(grunt) {
         // Inject live reload snippet
         if (options.livereload !== false) {
           if (options.livereload === true) {
-            options.livereload = 35729;
+            options.livereload = {port: 35729, hostname: options.hostname};
+          } else if (typeof options.livereload === 'number') {
+            options.livereload = {port: options.livereload, hostname: options.hostname};
           }
-
-          // TODO: Add custom ports here?
-          middleware.unshift(injectLiveReload({port: options.livereload, hostname: options.hostname}));
+          middleware.unshift(injectLiveReload(options.livereload));
           callback(null);
         } else {
           callback(null);

--- a/test/connect_test.js
+++ b/test/connect_test.js
@@ -182,7 +182,7 @@ exports.connect = {
       }
     }, function(res, body) {
       test.equal(res.statusCode, 200, 'should return 200');
-      test.ok(body.includes('hello.txt'), 'Listing should contain hello.txt');
+      test.ok(body.indexOf('hello.txt') !== -1, 'Listing should contain hello.txt');
       get('http://localhost:8005/fixtures/hello.txt', function(res, body) {
         test.equal(res.statusCode, 200, 'should return 200');
         test.equal(body, 'Hello world', 'Should display contents of /fixtures/hello.txt');
@@ -200,7 +200,7 @@ exports.connect = {
         accept: 'text/html'
       }
     }, function(res, body) {
-      test.ok(body.includes('35729/livereload.js'), 'Should contain livereload snippet.');
+      test.ok(body.indexOf('35729/livereload.js') !== -1, 'Should contain livereload snippet.');
 
       // check if livereload works with params
       get({
@@ -211,7 +211,7 @@ exports.connect = {
           accept: 'text/html'
         }
       }, function(res, body) {
-        test.ok(body.includes('35729/livereload.js'), 'Should contain livereload snippet.');
+        test.ok(body.indexOf('35729/livereload.js') !== -1, 'Should contain livereload snippet.');
         test.done();
       });
     });
@@ -226,7 +226,7 @@ exports.connect = {
         accept: 'text/html'
       }
     }, function(res, body) {
-      test.ok(body.includes('12345/livereload.js'), 'Should contain livereload snippet with configured port.');
+      test.ok(body.indexOf('12345/livereload.js') !== -1, 'Should contain livereload snippet with configured port.');
 
       // check if livereload works with params
       get({
@@ -237,7 +237,7 @@ exports.connect = {
           accept: 'text/html'
         }
       }, function(res, body) {
-        test.ok(body.includes('12345/livereload.js'), 'Should contain livereload snippet with configured port.');
+        test.ok(body.indexOf('12345/livereload.js') !== -1, 'Should contain livereload snippet with configured port.');
         test.done();
       });
     });
@@ -252,7 +252,7 @@ exports.connect = {
         accept: 'text/html'
       }
     }, function(res, body) {
-      test.ok(body.includes('https://example.org:54321/livereload.js?snipver=1'), 'Should contain livereload snippet with configured src.');
+      test.ok(body.indexOf('https://example.org:54321/livereload.js?snipver=1') !== -1, 'Should contain livereload snippet with configured src.');
 
       // check if livereload works with params
       get({
@@ -263,7 +263,7 @@ exports.connect = {
           accept: 'text/html'
         }
       }, function(res, body) {
-        test.ok(body.includes('https://example.org:54321/livereload.js?snipver=1'), 'Should contain livereload snippet with configured src.');
+        test.ok(body.indexOf('https://example.org:54321/livereload.js?snipver=1') !== -1, 'Should contain livereload snippet with configured src.');
         test.done();
       });
     });

--- a/test/connect_test.js
+++ b/test/connect_test.js
@@ -242,6 +242,32 @@ exports.connect = {
       });
     });
   },
+  livereload_general: function(test) {
+    test.expect(2);
+    get({
+      hostname: 'localhost',
+      port: 8019,
+      path: '/livereload.html',
+      headers: {
+        accept: 'text/html'
+      }
+    }, function(res, body) {
+      test.ok(body.indexOf('https://example.org:54321/livereload.js?snipver=1') !== -1, 'Should contain livereload snippet with configured src.');
+
+      // check if livereload works with params
+      get({
+        hostname: 'localhost',
+        port: 8019,
+        path: '/livereload.html?a=1&b=2#id',
+        headers: {
+          accept: 'text/html'
+        }
+      }, function(res, body) {
+        test.ok(body.indexOf('https://example.org:54321/livereload.js?snipver=1') !== -1, 'Should contain livereload snippet with configured src.');
+        test.done();
+      });
+    });
+  },
   custom_middleware: function(test) {
     var PORT = 8007;
     test.expect(4);

--- a/test/connect_test.js
+++ b/test/connect_test.js
@@ -182,7 +182,7 @@ exports.connect = {
       }
     }, function(res, body) {
       test.equal(res.statusCode, 200, 'should return 200');
-      test.ok(body.indexOf('hello.txt') !== -1, 'Listing should contain hello.txt');
+      test.ok(body.includes('hello.txt'), 'Listing should contain hello.txt');
       get('http://localhost:8005/fixtures/hello.txt', function(res, body) {
         test.equal(res.statusCode, 200, 'should return 200');
         test.equal(body, 'Hello world', 'Should display contents of /fixtures/hello.txt');
@@ -200,7 +200,7 @@ exports.connect = {
         accept: 'text/html'
       }
     }, function(res, body) {
-      test.ok(body.indexOf('35729/livereload.js') !== -1, 'Should contain livereload snippet.');
+      test.ok(body.includes('35729/livereload.js'), 'Should contain livereload snippet.');
 
       // check if livereload works with params
       get({
@@ -211,7 +211,7 @@ exports.connect = {
           accept: 'text/html'
         }
       }, function(res, body) {
-        test.ok(body.indexOf('35729/livereload.js') !== -1, 'Should contain livereload snippet.');
+        test.ok(body.includes('35729/livereload.js'), 'Should contain livereload snippet.');
         test.done();
       });
     });
@@ -226,7 +226,7 @@ exports.connect = {
         accept: 'text/html'
       }
     }, function(res, body) {
-      test.ok(body.indexOf('12345/livereload.js') !== -1, 'Should contain livereload snippet with configured port.');
+      test.ok(body.includes('12345/livereload.js'), 'Should contain livereload snippet with configured port.');
 
       // check if livereload works with params
       get({
@@ -237,7 +237,7 @@ exports.connect = {
           accept: 'text/html'
         }
       }, function(res, body) {
-        test.ok(body.indexOf('12345/livereload.js') !== -1, 'Should contain livereload snippet with configured port.');
+        test.ok(body.includes('12345/livereload.js'), 'Should contain livereload snippet with configured port.');
         test.done();
       });
     });
@@ -252,7 +252,7 @@ exports.connect = {
         accept: 'text/html'
       }
     }, function(res, body) {
-      test.ok(body.indexOf('https://example.org:54321/livereload.js?snipver=1') !== -1, 'Should contain livereload snippet with configured src.');
+      test.ok(body.includes('https://example.org:54321/livereload.js?snipver=1'), 'Should contain livereload snippet with configured src.');
 
       // check if livereload works with params
       get({
@@ -263,7 +263,7 @@ exports.connect = {
           accept: 'text/html'
         }
       }, function(res, body) {
-        test.ok(body.indexOf('https://example.org:54321/livereload.js?snipver=1') !== -1, 'Should contain livereload snippet with configured src.');
+        test.ok(body.includes('https://example.org:54321/livereload.js?snipver=1'), 'Should contain livereload snippet with configured src.');
         test.done();
       });
     });

--- a/test/connect_test.js
+++ b/test/connect_test.js
@@ -216,6 +216,32 @@ exports.connect = {
       });
     });
   },
+  livereload_port: function(test) {
+    test.expect(2);
+    get({
+      hostname: 'localhost',
+      port: 8018,
+      path: '/livereload.html',
+      headers: {
+        accept: 'text/html'
+      }
+    }, function(res, body) {
+      test.ok(body.indexOf('12345/livereload.js') !== -1, 'Should contain livereload snippet with configured port.');
+
+      // check if livereload works with params
+      get({
+        hostname: 'localhost',
+        port: 8018,
+        path: '/livereload.html?a=1&b=2#id',
+        headers: {
+          accept: 'text/html'
+        }
+      }, function(res, body) {
+        test.ok(body.indexOf('12345/livereload.js') !== -1, 'Should contain livereload snippet with configured port.');
+        test.done();
+      });
+    });
+  },
   custom_middleware: function(test) {
     var PORT = 8007;
     test.expect(4);


### PR DESCRIPTION
Allow all [livereload]() configuration options to be passed through.

Fixes #100